### PR TITLE
ALL_CURE

### DIFF
--- a/ERB/RPG/スキル関係/SKILL_TEMP.ERB
+++ b/ERB/RPG/スキル関係/SKILL_TEMP.ERB
@@ -1660,16 +1660,16 @@ RETURN LOCAL:3
 ;=========================================
 @ALL_CURE_STATE, ARG:0, ARG:1 = -1, ARG:2 = 0, ARG:3 = 1
 ;이상なキャラNo.の指定
-SIF (ARG:1) < 0
+SIF (ARG:0) < 0
 	RETURN 0
-LOCAL:0 = CPOS(ARG:1)
+LOCAL:0 = CPOS(ARG:0)
 ;대상キャラをPT内に限定する場合PT範囲内か?
 IF (ARG:2) == 0
 	SIF (LOCAL:0) < 0 || (LOCAL:0) > 16
 		RETURN 0
 ENDIF
 ;대상が死んでいる場合は회복不可
-SIF GET_STATE(CFLAG:(ARG:1):ステート) == "DYING"
+SIF GET_STATE(CFLAG:(ARG:0):ステート) == "DYING"
 	RETURN 0
 
 ;位置표시설정
@@ -1680,17 +1680,17 @@ ELSE
 ENDIF
 
 ;상태이상회복処理
-SELECTCASE GET_STATE(CFLAG:(ARG:1):ステート)
+SELECTCASE GET_STATE(CFLAG:(ARG:0):ステート)
 	CASE "FLY","GOOD","DYING","ORGY","HEAT"
 		RETURN 0
 	CASEELSE
-		SIF AUTO_PU_SKILL_라그나로크（ＡＮ）(ARG:1,"状態異常延長") > 0 && GET_STATE(CFLAG:(ARG:1):ステート) == "FLAME"
+		SIF AUTO_PU_SKILL_라그나로크（ＡＮ）(ARG:0,"状態異常延長") > 0 && GET_STATE(CFLAG:(ARG:0):ステート) == "FLAME"
 			RETURN 0
-		SIF GET_STATE(CFLAG:(ARG:1):ステート) == "PANIC" || GET_STATE(CFLAG:(ARG:1):ステート) == "CHARM"
-			CFLAG:(ARG:1):混乱매료리카バー = 1
-		PRINTFORML 　　TARGET:[%(LOCALS:0)%] %CALLNAME:(ARG:1),20,LEFT%　>>>>>>　状態回復！
-		CFLAG:(ARG:1):ステート = 0
-		CFLAG:(ARG:1):ステート経過ターン = 0
+		SIF GET_STATE(CFLAG:(ARG:0):ステート) == "PANIC" || GET_STATE(CFLAG:(ARG:0):ステート) == "CHARM"
+			CFLAG:(ARG:0):混乱매료리카バー = 1
+		PRINTFORML 　　TARGET:[%(LOCALS:0)%] %CALLNAME:(ARG:0),20,LEFT%　>>>>>>　状態回復！
+		CFLAG:(ARG:0):ステート = 0
+		CFLAG:(ARG:0):ステート経過ターン = 0
 ENDSELECT
 
 ;WAITで待つか?


### PR DESCRIPTION
ALL_CURE_STATE 함수 수정;변수를 ARG:0로 받고 ARG:1을 사용하는 오류교정.

eraMegaten_3909(全快修正)에서 이미 처리한 버그인 모양인데 패치 통합과정에서 실수하지 않았는지 재점검 필요.
아마 후속패치에서 해당 패치를 안 하고 배포했을 가능성 있음.

CURE_STATE_FIELD나 CURE_STATE_SINGLE 함수에서도 같은 패턴이 보이는데 다른 파일에서 호출하지 않다보니 오류 뿜을 일도 없으므로 관망.