### PR TITLE
[Bugfix]로카팔라의 동료추가 이벤트로 타케미 타에 대신에 아사쿠라 타에가 추가되는 버그의 수정.

### DIFF
--- a/ERB/RPG/ダンジョンアタック/ダンジョンデータ/DUNGEON13_ローカパーラ/1ローカパーライベント.ERB
+++ b/ERB/RPG/ダンジョンアタック/ダンジョンデータ/DUNGEON13_ローカパーラ/1ローカパーライベント.ERB
@@ -566,7 +566,7 @@ SELECTCASE RESULT
 		CALL INPUT_SELECT_D, "[0]타케미를 노예로 만든다/[1]아무것도 안한다 "
 		IF RESULT == 0
 			CALL MESSAGE_WINDOW_D, "타케미", "꺄악！…뭐　뭐야！？ "
-			CALL ADD_NEW_COMPANION,[[キャラ:타에]],100
+			CALL ADD_NEW_COMPANION,4666,100
 			PRINTFORML 타케미 타에를 손에 넣었다
 			SETBIT 던전플래그:13:22,2
 		ENDIF


### PR DESCRIPTION
# 내용
문맥상 P5타케미 타에가 추가되어야 하는 이벤트에서 아사쿠라 타에가 추가되는 버그.
원인으로는 [[キャラ:타에]]의 동작이 캐릭터의 이름으로 해당 캐릭터의 아이디를 찾아오는 것을 의도한 것으로 보이나,
타에는 동명이인이 존재하고, 타케미 타에는 「キャラ:타에(페르소나5)」로 별도로 지정되어있으므로 의도하지 않은 캐릭터의 ID가 불려오는 것으로 보임.
수정 방법으로는 [[キャラ:타에(페르소나5)]]로 변경과 4666의 ID직접 지정 두가지 방법이 있으나,
코드내 병용되는 것으로 보이므로, 어느쪽을 선택해도 상관없겠다 싶어 ID를 직접 지정함.